### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/ETHER_28J60/keywords.txt
+++ b/ETHER_28J60/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ETHER_28J60 KEYWORD1
+ETHER_28J60	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setup KEYWORD2
-serviceRequest KEYWORD2
-print KEYWORD2
-respond KEYWORD2
+setup	KEYWORD2
+serviceRequest	KEYWORD2
+print	KEYWORD2
+respond	KEYWORD2
 
 #
 #######################################

--- a/etherShield/keywords.txt
+++ b/etherShield/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EtherShield KEYWORD1
+EtherShield	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords